### PR TITLE
feat: trackspage and trackpage layout responsive mobile enhancements

### DIFF
--- a/apps/academy/src/components/AboutCourse.tsx
+++ b/apps/academy/src/components/AboutCourse.tsx
@@ -7,7 +7,7 @@ export default function AboutCourse({ lessonDescription, tags }: AboutCourseProp
   return (
     <article className="px-7 pt-14 lg:ml-16 lg:w-[42rem] lg:p-0 ">
       <h2 className="text-2xl font-bold lg:text-3xl">About This Course</h2>
-      <div className="mt-4">
+      <div className="mt-4 flex flex-col gap-2 lg:flex-row">
         {tags.map((tag, idx) => (
           <div
             key={idx}
@@ -15,7 +15,7 @@ export default function AboutCourse({ lessonDescription, tags }: AboutCourseProp
               idx % 3 === 0 ? "bg-[#FF0000]" : idx % 2 === 0 ? "bg-[#FAFF00]" : "bg-[#00F0FF]"
             } bg-opacity-40 p-2 backdrop-blur-md`}
           >
-            <div className="font-['Clash Display'] p-4 text-center text-sm font-semibold text-white">
+            <div className="font-['Clash Display'] p-4 text-center text-xs font-semibold text-white lg:text-sm">
               {tag}
             </div>
           </div>

--- a/apps/academy/src/components/LessonLayout.tsx
+++ b/apps/academy/src/components/LessonLayout.tsx
@@ -24,11 +24,11 @@ export default function LessonLayout({
         <h1 className="font-future text-3xl lg:text-8xl">{lessonTitle}</h1>
         <div className="ml-16 mt-7 h-px w-72 border border-white lg:w-[90%]"></div>
       </section>
-      <div className="flex-col justify-start lg:pt-24">
+      <div className="mx-3 flex-col justify-start pt-4 lg:pt-24">
         {/* <div className="">
           <AboutCourse lessonDescription={lessonDescription} />
         </div> */}
-        <div className="text-left ">
+        <div className="pl-6 text-left ">
           <CreatedBy
             author={author}
             authorPosition={authorPosition}
@@ -37,7 +37,7 @@ export default function LessonLayout({
           />
         </div>
       </div>
-      <div className="font-clash-display px-36 pt-16 text-xl font-medium tracking-wider	">
+      <div className="font-clash-display px-10 pt-12 text-xl font-medium tracking-wider lg:px-36 lg:pt-16	">
         {children}
       </div>
     </main>

--- a/apps/academy/src/pages/tracks/erc-20-solidity/index.tsx
+++ b/apps/academy/src/pages/tracks/erc-20-solidity/index.tsx
@@ -26,7 +26,7 @@ const IntroToEthereumPage = () => {
     },
   ];
   return (
-    <div className="relative mx-60 mb-40 mt-40 flex">
+    <div className="relative m-10 flex lg:mx-60 lg:mb-40 lg:mt-40">
       <TracksLayout
         trackTitle="ERC-20 Solidity Track"
         trackDescription="Need description for this track"
@@ -35,7 +35,7 @@ const IntroToEthereumPage = () => {
         trackAuthorTwitter="@_7i7o.eth, @Skruffster"
         tags={["Beginner", "Web3", "Eth", "Solidity", "ERC-20", "Foundry"]}
       >
-        <div className="flex w-full gap-10 p-20">
+        <div className="mt-14 flex flex-col gap-8 lg:w-full lg:flex-row lg:gap-10 lg:p-20">
           {tracksArray.map((track, idx) => (
             <Link href={track.path} key={idx}>
               <TrackCard

--- a/apps/academy/src/pages/tracks/index.tsx
+++ b/apps/academy/src/pages/tracks/index.tsx
@@ -50,42 +50,26 @@ const TracksPage = () => {
     // },
   ];
   return (
-    // <div className="relative mx-60 mb-40 mt-40 flex  ">
-    //   <div className="w-[50%] border text-white">TracksPage Background Image</div>
-    //   <div className="w-[50%] p-20">
-    //     {tracksArray.map((track, idx) => (
-    //       <Link href="/tracks/intro-to-ethereum" key={idx}>
-    //         <TrackCard
-    //           imgSrc={track.imgPath}
-    //           tags={track.tags}
-    //           title={track.title}
-    //           author={track.author}
-    //           description={track.description}
-    //         />
-    //       </Link>
-    //     ))}
-    //   </div>
-    // </div>
-    <div className="flex h-full max-h-screen w-full flex-col space-y-10 overflow-hidden bg-black lg:flex-row">
+    <div className="flex h-full w-full flex-col space-y-10 overflow-hidden bg-black lg:h-screen lg:max-h-screen lg:flex-row">
       <div
-        className="flex h-full flex-1 flex-col items-center justify-between 
-overflow-hidden bg-[url('/fundamental-bg.jpeg')] bg-cover bg-no-repeat object-center pt-[300px] md:pt-[325px] lg:fixed lg:inset-y-0 lg:w-1/2"
+        className="flex h-full min-h-screen flex-1 flex-col items-center justify-between overflow-hidden 
+bg-[url('/fundamental-bg.jpeg')] bg-cover bg-no-repeat object-center pt-[300px]  lg:fixed lg:inset-y-0 lg:h-screen lg:w-1/2"
       >
         <div>
           <h2 className="text-bttf text-3xl text-white sm:text-5xl">Fundamentals</h2>
         </div>
         <div className="md:hidden" />
         <div className="flex justify-center">
-          <p className="max-w-[275px] text-center text-2xl font-bold text-white sm:max-w-xs sm:text-3xl md:max-w-full">
+          <p className="max-w-[275px] text-center text-xl font-bold text-white sm:max-w-xs md:max-w-full lg:text-2xl">
             Nail the basics and then take on a track.
           </p>
         </div>
         <div />
       </div>
-      <div className="h-full overflow-hidden lg:fixed lg:right-0 lg:top-20 lg:h-screen lg:w-1/2">
-        <div className="flex w-full flex-1 flex-col space-y-10 overflow-hidden overflow-y-scroll bg-black px-8 pb-14 lg:max-h-screen lg:pb-28">
-          <div className="flex w-full justify-center overflow-hidden md:px-8 lg:pb-10">
-            <div className="grid w-fit justify-center gap-5 overflow-hidden sm:grid-cols-2 md:gap-x-10 md:gap-y-8 lg:grid-cols-1 lg:pb-8 xl:grid-cols-2">
+      <div className="flex-0 flex lg:fixed lg:right-0 lg:top-20 lg:h-screen lg:w-1/2">
+        <div className="relative flex max-h-screen w-full flex-1 flex-row  space-y-10 overflow-y-scroll bg-black px-8 pb-14 lg:pb-28">
+          <div className="flex w-full justify-center md:px-8 lg:pb-10">
+            <div className="grid w-fit justify-center gap-5 sm:grid-cols-2 md:gap-x-10 md:gap-y-8 lg:grid-cols-1 lg:pb-8 xl:grid-cols-2">
               {tracksArray.map((track, idx) => (
                 <Link href={track.trackPath} key={idx}>
                   <TrackCard

--- a/apps/academy/src/pages/tracks/intro-to-ethereum/index.tsx
+++ b/apps/academy/src/pages/tracks/intro-to-ethereum/index.tsx
@@ -44,7 +44,7 @@ const IntroToEthereumPage = () => {
         trackAuthorTwitter="@wolovim.eth"
         tags={["Beginner", "Web3", "Eth"]}
       >
-        <div className="mt-14 flex flex-col gap-8 lg:w-full lg:gap-10 lg:p-20">
+        <div className="mt-14 flex flex-col gap-8 lg:w-full lg:flex-row lg:gap-10 lg:p-20">
           {tracksArray.map((track, idx) => (
             <Link href={track.path} key={idx}>
               <TrackCard

--- a/apps/academy/src/pages/tracks/nft-solidity/1.mdx
+++ b/apps/academy/src/pages/tracks/nft-solidity/1.mdx
@@ -1208,11 +1208,4 @@ peers!
 <br />
 <br />
 
-import { ContributorFooter } from "../../../components/mdx/ContributorFooter";
-
-<ContributorFooter
-  authors={["_7i7o", "meowy", "piablo"]}
-  reviewers={["georgemac510"]}
-  contributors={["mveve"]}
-/>
 </LessonLayout>

--- a/apps/academy/src/pages/tracks/nft-solidity/2.mdx
+++ b/apps/academy/src/pages/tracks/nft-solidity/2.mdx
@@ -974,11 +974,4 @@ in the mean time, and share your new found wisdom with our community.
 Go forth, test, and prosper knowing you have confidence in the code you're
 deploying into the world.
 
-import { ContributorFooter } from "../../../components/mdx/ContributorFooter";
-
-<ContributorFooter
-  authors={["brianfive", "piablo"]}
-  reviewers={["georgemac510", "wolovim"]}
-  contributors={[]}
-/>
 </LessonLayout>

--- a/apps/academy/src/pages/tracks/nft-solidity/index.tsx
+++ b/apps/academy/src/pages/tracks/nft-solidity/index.tsx
@@ -35,7 +35,7 @@ const IntroToEthereumPage = () => {
     },
   ];
   return (
-    <div className="relative mx-60 mb-40 mt-40 flex">
+    <div className="relative m-10 flex lg:mx-60 lg:mb-40 lg:mt-40">
       <TracksLayout
         trackTitle="NFT Track"
         trackDescription="Multi Tiered NFTs: A User-Friendly Guide to Building ERC721 Collections"
@@ -44,7 +44,7 @@ const IntroToEthereumPage = () => {
         trackAuthorTwitter="@_7i7o.eth"
         tags={["Beginner", "Web3", "Eth"]}
       >
-        <div className="flex w-full gap-10 p-20">
+        <div className="mt-14 flex flex-col gap-8 lg:w-full lg:flex-row lg:gap-10 lg:p-20">
           {tracksArray.map((track, idx) => (
             <Link href={track.path} key={idx}>
               <TrackCard


### PR DESCRIPTION
<!-- Description of PR... -->

## Changes

- fixed mobile tracks page layout `/tracks`
- fixed mobile track detail page layout `/tracks/intro-to-ethereum` or `/tracks/nft-solidity`
- deleted unnused old contributors component on nft-solidity track's lessons