### PR TITLE
chore: dao brand guidelines

### DIFF
--- a/apps/academy/src/data/contributors.ts
+++ b/apps/academy/src/data/contributors.ts
@@ -17,7 +17,7 @@ export const contributors: ContributorLookup = {
     moreInfoUrl: "https://brianfive.xyz",
     avatarUrl: "https://brianfive.xyz/profile.png",
     about:
-      "Brian has been a member of the DeveloperDAO since November 2021, and enjoys building Web3 user experiences and smart contracts. Also active with Next.js, React and Serverless.",
+      "Brian has been a member of the Developer DAO since November 2021, and enjoys building Web3 user experiences and smart contracts. Also active with Next.js, React and Serverless.",
   },
   piablo: {
     displayName: "piablo",
@@ -38,7 +38,7 @@ export const contributors: ContributorLookup = {
     displayName: "7i7o",
     moreInfoUrl: "https://github.com/7i7o",
     avatarUrl: "https://avatars.githubusercontent.com/u/84824996?v=4",
-    about: "7i7o has been a member of the DeveloperDAO since October 2021.",
+    about: "7i7o has been a member of the Developer DAO since October 2021.",
   },
   mveve: {
     displayName: "mveve",

--- a/apps/academy/src/pages/index.tsx
+++ b/apps/academy/src/pages/index.tsx
@@ -18,7 +18,7 @@ const Home: NextPageWithLayout = () => {
             </div>
           </div>
           <div className="description max-w-lg">
-            <p>Become a web3 developer with DeveloperDAO.</p>
+            <p>Become a web3 developer with Developer DAO.</p>
           </div>
           <div className="hidden w-full items-center justify-center md:flex">
             <Icons.scroll className="h-16 w-16" />
@@ -47,7 +47,7 @@ Home.getLayout = function getLayout(page: ReactElement) {
   return (
     <PageSeoLayout
       title="Developer DAO Academy" // DEV_NOTE: This is for the next-seo per page config
-      description="Become a web3 developer with DeveloperDAO." // DEV_NOTE: This is for the next-seo per page config
+      description="Become a web3 developer with Developer DAO." // DEV_NOTE: This is for the next-seo per page config
     >
       {page}
     </PageSeoLayout>

--- a/apps/academy/src/pages/tracks/index.tsx
+++ b/apps/academy/src/pages/tracks/index.tsx
@@ -62,7 +62,7 @@ bg-[url('/fundamental-bg.jpeg')] bg-cover bg-no-repeat object-center pt-[300px] 
         <div className="md:hidden" />
         <div className="flex justify-center">
           <p className="max-w-[275px] text-center text-xl font-bold text-white sm:max-w-xs md:max-w-full lg:text-2xl">
-            DeveloperDAO learning tracks are designed <br /> to get you from 0 to 1.
+            Developer DAO learning tracks are designed <br /> to get you from 0 to 1.
           </p>
         </div>
         <div />

--- a/packages/ui/src/components/Banners/LearnWeb3Banner.tsx
+++ b/packages/ui/src/components/Banners/LearnWeb3Banner.tsx
@@ -115,7 +115,7 @@ export const LearnWeb3Banner: FC<HomePageBannerProps> = ({ href }) => {
         </CardHeader>
         <CardContent className="description max-w-xl p-1">
           <p>
-            DeveloperDAO Academy offers learning resources to help you learn how to build web3
+            Developer DAO Academy offers learning resources to help you learn how to build web3
             technologies.
           </p>
         </CardContent>


### PR DESCRIPTION
## Changes

quick one: `Developer DAO` appears without a space in a few locations