### PR TITLE
fix: remove author from card title

### DIFF
--- a/packages/ui/src/components/Cards/TrackCard.tsx
+++ b/packages/ui/src/components/Cards/TrackCard.tsx
@@ -14,7 +14,7 @@ export interface TrackCardProps {
   description: string;
 }
 
-const TrackCard: FC<TrackCardProps> = ({ imgSrc, tags, title, description, author }) => {
+const TrackCard: FC<TrackCardProps> = ({ imgSrc, tags, title, description }) => {
   return (
     <div className="min-h-[30rem] rounded-[51px] bg-gradient-to-r from-[#E9E9E9] via-black to-[#E9E9E9] p-0.5">
       <Card className="track min-h-[30rem] rounded-[51px] bg-black hover:bg-zinc-900">
@@ -36,10 +36,7 @@ const TrackCard: FC<TrackCardProps> = ({ imgSrc, tags, title, description, autho
           ))}
         </div>
         <CardHeader className="space-y-4 pb-10">
-          <div>
-            <CardTitle className="title">{title}</CardTitle>
-            <CardTitle className="title">By {author}</CardTitle>
-          </div>
+          <CardTitle className="title">{title}</CardTitle>
           <CardDescription className="description">{description}</CardDescription>
           <Separator className="opacity-10" />
         </CardHeader>


### PR DESCRIPTION
## Changes

following discussion in discord, removes author from crowded card title. (author still appears on lesson and track pages)

before:
<img width="694" alt="Screenshot 2024-01-20 at 2 08 35 PM" src="https://github.com/Developer-DAO/academy-turbo/assets/3621728/8770f256-6511-484f-8a2b-28bff4685c08">
after: 
<img width="653" alt="Screenshot 2024-01-20 at 2 18 49 PM" src="https://github.com/Developer-DAO/academy-turbo/assets/3621728/4cc123d2-fc49-4b12-91a2-b679af80d820">

obviously still more styling cleanup to do, between the tags hanging off and the too-tall vertical height