### PR TITLE
feat: mdx baseline styles

### DIFF
--- a/apps/academy/src/components/mdx/Components.tsx
+++ b/apps/academy/src/components/mdx/Components.tsx
@@ -27,15 +27,15 @@ const Components = {
     }
 
     // return <Code fontSize="md" wordBreak="break-all" {...props} />;
-    return <div className="text-md break-all" {...props} />;
+    return <span className="text-md inline-code break-all" {...props} />;
   },
-  h1: (props: any) => <h1 apply="mdx.h1" className="text-4xl" {...props} />,
-  h2: (props: any) => <h2 apply="mdx.h2" className="text-3xl" {...props} />,
-  h3: (props: any) => <h3 apply="mdx.h3" className="text-2xl" {...props} />,
-  h4: (props: any) => <h4 apply="mdx.h4" className="text-xl" {...props} />,
+  h1: (props: any) => <h1 apply="mdx.h1" className="h1" {...props} />,
+  h2: (props: any) => <h2 apply="mdx.h2" className="h2" {...props} />,
+  h3: (props: any) => <h3 apply="mdx.h3" className="h3" {...props} />,
+  h4: (props: any) => <h4 apply="mdx.h4" className="h4" {...props} />,
   p: (props: any) => <p apply="mdx.p" className="text-xl" {...props} />,
   a: (props: any) => <a apply="mdx.a" {...props} />,
-  ul: (props: any) => <ul apply="mdx.ul" className="text-xl" {...props} />,
+  ul: (props: any) => <ul apply="mdx.ul" className="ul text-xl" {...props} />,
   img: (props: any) => <img apply="mdx.image" className="m-0" alt="" {...props} />,
   SideDrawer,
   Callout,

--- a/packages/ui/src/styles.css
+++ b/packages/ui/src/styles.css
@@ -149,6 +149,33 @@
   }
 }
 
+.h1 {
+  @apply my-8 text-4xl font-bold;
+}
+
+.h2 {
+  @apply my-6 text-3xl font-bold;
+}
+
+.h3 {
+  @apply my-6 text-2xl font-bold;
+}
+
+.h4 {
+  @apply my-6 text-xl font-bold;
+}
+
+.ul {
+  @apply my-4 ml-4 list-inside list-disc;
+}
+
+.inline-code {
+  font-family: "Courier New", monospace;
+  background-color: #1c1c1c;
+  padding: 0.2em 0.4em;
+  border-radius: 4px;
+}
+
 .main-container {
   @apply container mx-auto max-w-7xl;
 }


### PR DESCRIPTION
## Changes

basic styling for header, list, and code tags in mdx. optimization to design spec should happen at some point, but here's an mvp. example that includes all three (h3, inline-code via backticks, and unordered list):

<img width="473" alt="Screenshot 2024-01-21 at 9 22 37 PM" src="https://github.com/Developer-DAO/academy-turbo/assets/3621728/64f6951b-af19-4f01-920b-03fe45e5f182">
