### PR TITLE
fix: eth intro copy, track titles and description

### DIFF
--- a/apps/academy/src/pages/tracks/erc-20-solidity/index.tsx
+++ b/apps/academy/src/pages/tracks/erc-20-solidity/index.tsx
@@ -28,7 +28,7 @@ const IntroToEthereumPage = () => {
   return (
     <div className="relative m-10 flex lg:mx-auto lg:max-w-screen-lg">
       <TracksLayout
-        trackTitle="ERC-20 Solidity Track"
+        trackTitle="Build a Fungible Token"
         trackDescription="Learn to create ERC-20 tokens using Foundry, progressing from the basics to advanced customisation. We will be exploring, testing, real-world applications, security practices, and the role of tokens in decentralised ecosystems. From DeFi to DAO's and everything in between, thanks to its simplicity, but versatility, the ERC-20 is going nowhere. Start with Solidity, or dive directly into token creation — empowering you to contribute to blockchain projects."
         trackAuthor="_7i7o, piablo"
         trackAuthorDescription="Authors are active Developer DAO members"

--- a/apps/academy/src/pages/tracks/fundamentals/index.tsx
+++ b/apps/academy/src/pages/tracks/fundamentals/index.tsx
@@ -106,17 +106,7 @@ const FundamentalsTrackPage = () => {
         trackAuthor="elPiablo, georgemac510"
         trackAuthorDescription="The authors have a wealth of knowledge in the field of education and pedagogy"
         trackAuthorTwitter="@GeorgeMac510, @Skruffster"
-        tags={[
-          "Entry",
-          "Explorer",
-          "Infra",
-          "Blockchain",
-          "Back-end",
-          "Front-end",
-          "Bash",
-          "RPC",
-          "Node",
-        ]}
+        tags={["Entry", "Explorer", "Infra", "Blockchain", "Back-end", "Front-end", "Bash", "RPC"]}
       >
         <div className="mt-14 flex flex-col gap-8 lg:grid lg:w-full lg:grid-cols-3 lg:gap-10">
           {lessonsArray.map((track, idx) => (

--- a/apps/academy/src/pages/tracks/index.tsx
+++ b/apps/academy/src/pages/tracks/index.tsx
@@ -14,25 +14,25 @@ const TracksPage = () => {
       trackPath: "/tracks/fundamentals",
     },
     {
-      title: "A Developer's Guide to Ethereum, Part I, II & III",
+      title: "A Developer's Guide to Ethereum",
       author: "wolovim",
       imgPath: "/image16.png",
       description:
-        "Introduction to Ethereum with web3.py and Python. Grasp blockchain basics, Ethereum's decentralization, and smart contracts with practical insights. Code included for hands-on learning.",
+        "An accessible introduction to Ethereum via web3.py and Python. Grasp blockchain basics, Ethereum's decentralization, and smart contracts with practical insights. Code included for hands-on learning.",
       tags: ["Entry", "Blockchain", "Ethereum"],
       trackPath: "/tracks/intro-to-ethereum",
     },
     {
-      title: "NFT track Part I-V",
+      title: "Build a Tiered NFT",
       author: "7i7o, piablo, georgemac510, brianfive, ropats16, meowy, mveve",
       imgPath: "/image16.png",
       description:
-        "Get stuck right into Solidity and on to the NFT train. You'll be building your own tiered ERC-721 token sets, creating a Test Driven Development suite, hosting your files on Web3 storage, and creating on your own front-end dApp. The full-stack-track.",
+        "After a gentle introduction to Solidity, you'll be building your own tiered ERC-721 token sets using test-driven development, hosting your files on Web3 storage, and creating on your own front-end dApp. The full-stack-track.",
       tags: ["Entry", "Explorer", "ERC-721"],
       trackPath: "/tracks/nft-solidity",
     },
     {
-      title: "ERC-20 Solidity Track",
+      title: "Build a Fungible Token",
       author: "_7i7o, piablo",
       imgPath: "/image16.png",
       description:
@@ -40,15 +40,6 @@ const TracksPage = () => {
       tags: ["Entry", "ERC-20", "Foundry"],
       trackPath: "/tracks/erc-20-solidity",
     },
-    // {
-    //   title: "Intro to Ethereum Part I, II & III.",
-    //   author: "wolovim",
-    //   imgPath: "/image16.png",
-    //   description:
-    //     "Foundry is a blazing fast, portable and modular toolkit for Ethereum application development written in Rust.",
-    //   tags: ["Beginner", "Web3", "DeFi"],
-    //   trackPath: "/tracks/intro-to-ethereum",
-    // },
   ];
   return (
     <div className="flex h-full w-full flex-col space-y-10 overflow-hidden bg-black lg:h-screen lg:max-h-screen lg:flex-row">

--- a/apps/academy/src/pages/tracks/intro-to-ethereum/1.mdx
+++ b/apps/academy/src/pages/tracks/intro-to-ethereum/1.mdx
@@ -19,7 +19,7 @@ import Question from "../../../components/mdx/Question";
 >
 
 So, you’ve heard about this [Ethereum](https://ethereum.org/) thing and are
-ready to venture down the rabbit hole? This post will quickly cover some
+ready to venture down the rabbit hole? This lesson will quickly cover some
 blockchain basics, then get you interacting with a simulated Ethereum node -
 reading block data, checking account balances, and sending transactions. Along
 the way, we’ll highlight the differences between traditional ways of building
@@ -28,7 +28,7 @@ is on the concepts, not a final product.
 
 ### **(Soft) prerequisites**
 
-This post aspires to be accessible to a wide range of developers. Python tools
+This lesson aspires to be accessible to a wide range of developers. Python tools
 will be involved, but they are just a vehicle for the ideas. Reproducing the
 code is not required, but may help the ideas sink in. For those coding along,
 I'm making just a few assumptions about what you already know, so we can quickly
@@ -441,12 +441,6 @@ the tune of 21000 wei.
 This seems as good a place as any to take a break. The rabbit hole continues on,
 and we’ll continue exploring in part two of this series. Some concepts to come:
 a deeper look into accounts, smart contracts, tooling and how to stake out on
-your own as an Ethereum developer. Have follow-up questions? Requests for new
-content? Let me know on [Twitter](https://twitter.com/wolovim).
-
-<Callout emoji="💡">
-  **Note**: This series is being converted from the [Snake
-  Charmers](https://snakecharmers.ethereum.org/) blog.
-</Callout>
+your own as an Ethereum developer.
 
 </LessonLayout>

--- a/apps/academy/src/pages/tracks/intro-to-ethereum/index.tsx
+++ b/apps/academy/src/pages/tracks/intro-to-ethereum/index.tsx
@@ -7,7 +7,7 @@ import TracksLayout from "@/components/TracksLayout";
 const IntroToEthereumPage = () => {
   const lessonsArray = [
     {
-      title: "A Developer's Guide to Ethereum, Pt.1",
+      title: "A Developer's Guide to Ethereum, Pt. 1",
       author: "wolovim",
       imgPath: "/image16.png",
       description:
@@ -16,7 +16,7 @@ const IntroToEthereumPage = () => {
       path: "/tracks/intro-to-ethereum/1",
     },
     {
-      title: "A Developer's Guide to Ethereum, Pt.2",
+      title: "A Developer's Guide to Ethereum, Pt. 2",
       author: "wolovim",
       imgPath: "/image16.png",
       description:
@@ -25,7 +25,7 @@ const IntroToEthereumPage = () => {
       path: "/tracks/intro-to-ethereum/2",
     },
     {
-      title: "A Developer's Guide to Ethereum, Pt.3",
+      title: "A Developer's Guide to Ethereum, Pt. 3",
       author: "wolovim",
       imgPath: "/image16.png",
       description:

--- a/apps/academy/src/pages/tracks/intro-to-ethereum/index.tsx
+++ b/apps/academy/src/pages/tracks/intro-to-ethereum/index.tsx
@@ -38,7 +38,7 @@ const IntroToEthereumPage = () => {
     <div className="relative m-10 flex lg:mx-auto lg:max-w-screen-lg">
       <TracksLayout
         trackTitle="A Developer's Guide to Ethereum"
-        trackDescription="Begin your journey with A Developer's Guide to Ethereum, leveraging web3.py and Python. Explore blockchain essentials, Ethereum's decentralized realm, and learn about smart contracts with practical insights. The series blends theory and hands-on learning, providing code to reinforce understanding. Ideal for developers transitioning to Ethereum through a Python lens."
+        trackDescription="An accessible introduction to Ethereum via web3.py and Python. Grasp blockchain basics, Ethereum's decentralization, and smart contracts with practical insights. Code included for hands-on learning, but no programming expertise required."
         trackAuthor="wolovim"
         trackAuthorDescription="wolovim is a Full Stack Python Developer at the Ethereum Foundation."
         trackAuthorTwitter="@wolovim.eth"

--- a/apps/academy/src/pages/tracks/nft-solidity/index.tsx
+++ b/apps/academy/src/pages/tracks/nft-solidity/index.tsx
@@ -55,8 +55,8 @@ const IntroToEthereumPage = () => {
   return (
     <div className="relative m-10 flex lg:mx-auto lg:max-w-screen-lg">
       <TracksLayout
-        trackTitle="NFT Track"
-        trackDescription="This ERC-721 NFT track will take you as a being a complete beginner, not only learning the basics of Solidity, but have you building a series of meaningful, real-world, NFT projects, with some nifty approaches on how to code them. You'll enhance your skills along the way, by creating your own Test Driven Development suite to ensure your smart contracts are safe to deploy to a live blockchain. And finally you'll be creating a tasteful front-end interface so your users can mint your ERC-721 tokens in their desired tier. All in all, a rewarding coding journey."
+        trackTitle="Build a Tiered NFT"
+        trackDescription="This ERC-721 NFT track will take you from complete beginner to building a series of meaningful, real-world, NFT projects. You'll enhance your skills along the way by using test-driven development to gain confidence that your smart contracts are safe to deploy to a live blockchain. And finally you'll be creating a tasteful front-end interface so your users can mint your ERC-721 tokens in their desired tier. All in all, a rewarding coding journey."
         trackAuthor="7i7o, piablo, georgemac510, brianfive, ropats16, meowy, mveve"
         trackAuthorDescription="Authors are active Developer DAO members"
         trackAuthorTwitter="@_7i7o.eth"

--- a/packages/ui/src/styles.css
+++ b/packages/ui/src/styles.css
@@ -238,7 +238,7 @@
 }
 
 .track .title {
-  @apply w-full text-xl font-bold leading-5 text-[#D8D8D8];
+  @apply w-full text-xl leading-5 text-[#D8D8D8];
   font-family: var(--font-clash-display);
 }
 


### PR DESCRIPTION
# Changes

- copy tweaks in intro to eth, pt 1
- title and description tweaks for tracks on index and detail pages
- reduce track card title boldness by a smidge

before:
<img width="652" alt="Screenshot 2024-01-25 at 3 51 08 PM" src="https://github.com/Developer-DAO/academy-turbo/assets/3621728/f2c44ca6-b0f4-44dc-8197-45b64d1066a6">

after: 
<img width="651" alt="Screenshot 2024-01-25 at 4 38 14 PM" src="https://github.com/Developer-DAO/academy-turbo/assets/3621728/ffb0c1ab-e92d-40b3-9865-10d8887c9934">

