### PR TITLE
fix: style mdx paragraph tags

### DIFF
--- a/apps/academy/src/components/mdx/Components.tsx
+++ b/apps/academy/src/components/mdx/Components.tsx
@@ -33,7 +33,7 @@ const Components = {
   h2: (props: any) => <h2 apply="mdx.h2" className="h2" {...props} />,
   h3: (props: any) => <h3 apply="mdx.h3" className="h3" {...props} />,
   h4: (props: any) => <h4 apply="mdx.h4" className="h4" {...props} />,
-  p: (props: any) => <p apply="mdx.p" className="text-xl" {...props} />,
+  p: (props: any) => <p apply="mdx.p" className="mdx-p text-xl" {...props} />,
   a: (props: any) => <a apply="mdx.a" {...props} />,
   ul: (props: any) => <ul apply="mdx.ul" className="ul text-xl" {...props} />,
   img: (props: any) => <img apply="mdx.image" className="m-0" alt="" {...props} />,

--- a/packages/ui/src/styles.css
+++ b/packages/ui/src/styles.css
@@ -165,6 +165,10 @@
   @apply my-6 text-xl font-bold;
 }
 
+.mdx-p {
+  @apply my-4;
+}
+
 .ul {
   @apply my-4 ml-4 list-inside list-disc;
 }


### PR DESCRIPTION
## Changes

baseline style for `p` tags in mdx, adding some margin on top and bottom

before:
<img width="333" alt="Screenshot 2024-01-28 at 10 23 41 PM" src="https://github.com/Developer-DAO/academy-turbo/assets/3621728/3c64dde1-b660-4a7f-9129-0b097439f104">


after:
<img width="292" alt="Screenshot 2024-01-28 at 10 22 31 PM" src="https://github.com/Developer-DAO/academy-turbo/assets/3621728/728ab9e2-4390-46b9-8f27-3e4acc688975">
