### PR TITLE
fix: style mdx a tags

### DIFF
--- a/apps/academy/src/components/mdx/Components.tsx
+++ b/apps/academy/src/components/mdx/Components.tsx
@@ -34,7 +34,7 @@ const Components = {
   h3: (props: any) => <h3 apply="mdx.h3" className="h3" {...props} />,
   h4: (props: any) => <h4 apply="mdx.h4" className="h4" {...props} />,
   p: (props: any) => <p apply="mdx.p" className="mdx-p text-xl" {...props} />,
-  a: (props: any) => <a apply="mdx.a" {...props} />,
+  a: (props: any) => <a apply="mdx.a" className="mdx-a" {...props} />,
   ul: (props: any) => <ul apply="mdx.ul" className="ul text-xl" {...props} />,
   img: (props: any) => <img apply="mdx.image" className="m-0" alt="" {...props} />,
   SideDrawer,

--- a/packages/ui/src/styles.css
+++ b/packages/ui/src/styles.css
@@ -169,6 +169,10 @@
   @apply my-4;
 }
 
+.mdx-a {
+  @apply underline;
+}
+
 .ul {
   @apply my-4 ml-4 list-inside list-disc;
 }


### PR DESCRIPTION
## Changes

- adds baseline style to mdx anchor tags, just adding an underline for now. design team can do what they want with it post-mvp.
- fixes #106 