### PR TITLE
fix: mdx font legibility

### DIFF
--- a/apps/academy/src/components/LessonLayout.tsx
+++ b/apps/academy/src/components/LessonLayout.tsx
@@ -37,7 +37,7 @@ export default function LessonLayout({
           />
         </div>
       </div>
-      <div className="font-clash-display px-10 pt-12 text-xl font-medium tracking-wider lg:px-36 lg:pt-16	">
+      <div className="font-poppins px-10 pt-12 text-xl font-medium tracking-wider lg:px-36 lg:pt-16">
         {children}
       </div>
     </main>

--- a/packages/ui/src/styles.css
+++ b/packages/ui/src/styles.css
@@ -150,27 +150,32 @@
 }
 
 .h1 {
-  @apply my-8 text-4xl font-bold;
+  @apply my-8 text-4xl font-semibold;
+  font-family: var(--font-clash-display);
 }
 
 .h2 {
-  @apply my-6 text-3xl font-bold;
+  @apply my-6 text-3xl font-semibold;
+  font-family: var(--font-clash-display);
 }
 
 .h3 {
-  @apply my-6 text-2xl font-bold;
+  @apply my-6 text-2xl font-semibold;
+  font-family: var(--font-clash-display);
 }
 
 .h4 {
-  @apply my-6 text-xl font-bold;
+  @apply my-6 text-xl font-semibold;
+  font-family: var(--font-clash-display);
 }
 
 .mdx-p {
-  @apply my-4;
+  @apply my-4 font-light;
+  font-family: var(--font-poppins);
 }
 
 .ul {
-  @apply my-4 ml-4 list-inside list-disc;
+  @apply my-4 ml-4 list-inside list-disc font-light;
 }
 
 .inline-code {


### PR DESCRIPTION
## Changes

- changes content font to poppins for better legibility
- fixes #91 

before:
<img width="402" alt="Screenshot 2024-01-29 at 1 46 55 PM" src="https://github.com/Developer-DAO/academy-turbo/assets/3621728/ea37b3c5-239e-46eb-a743-e8cf5dabb0fa">

after:
<img width="417" alt="Screenshot 2024-01-29 at 1 46 35 PM" src="https://github.com/Developer-DAO/academy-turbo/assets/3621728/b3c9ddeb-4d15-408c-a812-0bdc986b422b">