### PR TITLE
feat: update 2 out of 3 lessons with POKT rpc providers

### DIFF
--- a/apps/academy/src/pages/tracks/erc-20-solidity/2.mdx
+++ b/apps/academy/src/pages/tracks/erc-20-solidity/2.mdx
@@ -693,9 +693,9 @@ Overview of our values:
 
 - **RAW_PRIVATE_KEY**: Here we shall paste our development wallet's private key
   after the `=` sign
-- **ETH_RPC_URL**: This is the token from our RPC provider, we are using a
-  public one but you can use POKT, Infura, Alchemy, Quicknode or whatever
-  provider you prefer
+- **ETH_RPC_URL**: This is the token from the RPC provider. We are using Ankr's
+  public one here, but you could also choose to use a POKT Network Gateway such
+  as Grove, or Nodies, or another provider that you prefer.
 - **CHAIN**: The blockchain where we will be deploying out contract. We are
   using the Sepolia testnet since this is not intended to be on mainnet.
 - **ETHERSCAN_API_KEY**: Here we will use our Etherscan API KEY so we can verify

--- a/apps/academy/src/pages/tracks/nft-solidity/2.mdx
+++ b/apps/academy/src/pages/tracks/nft-solidity/2.mdx
@@ -876,14 +876,14 @@ hardhat.config.js
 In order to deploy to a real testnet we'll need:
 
 - An Ethereum wallet that can connect to Sepolia.
-  [Download Zerion here](https://devdao.to/get-zerion) as a good example
+  [Zerion](https://devdao.to/get-zerion) is a good example
 - Some Sepolia-ETH. You can ask for some in a faucet, it's free, although some
   are faster than others! Options: [#1](https://sepoliafaucet.com/),
   [#2](https://testnet-faucet.com/sepolia/),
   [#3](https://faucet.quicknode.com/ethereum/sepolia)
-- An API Key from an Ethereum RPC Node Provider
-  ([Alchemy](https://www.alchemy.com/), [Infura](https://infura.io/),
-  [Ankr](https://rpc.ankr.com/eth_sepolia)
+- An API Key from an Ethereum RPC Node Provider, e.g.
+  [Grove](https://www.grove.city/), [Nodies](https://www.nodies.app/)
+  - If you're a Developer_DAO member, check out [D_D Grove Perks](https://devdao.to/grove-perk)
 - A minor change in the Hardhat configuration file
 
 First and foremost, **security**. We are exploring new grounds, experimenting,
@@ -907,9 +907,7 @@ tokens for developing.
 
 We need to inform Hardhat which node we are using to connect to the blockchain
 network. Once you have your wallet funded with test ETH, you'll need sign up for
-one of the Ethereum RPC Node Providers. Alchemy and Infura are the most used.
-And Ankr has a 'community endpoint' which doesn't require a dedicated sign up,
-to list a few options.
+an Ethereum RPC Node Providers. We mentioned a few earlier.
 
 After signing up, you'll be asked to create an App. Be sure to select the
 Sepolia network there. When the app is created, you'll see a 'View Key' button,
@@ -927,7 +925,7 @@ require("@nomicfoundation/hardhat-toolbox");
 
 const WALLET_PRIVATE_KEY = "YOUR-PRIVATE-KEY-DONT-SHARE";
 
-const RPC_API_KEY = "YOUR-API-KEY-FROM-INFURA-OR-ALCHEMY";
+const RPC_API_KEY = "YOUR-API-KEY-FROM-YOUR-RPC-PROVIDER";
 
 /**
  * @type import('hardhat/config').HardhatUserConfig

--- a/apps/academy/src/pages/tracks/nft-solidity/2.mdx
+++ b/apps/academy/src/pages/tracks/nft-solidity/2.mdx
@@ -925,7 +925,7 @@ require("@nomicfoundation/hardhat-toolbox");
 
 const WALLET_PRIVATE_KEY = "YOUR-PRIVATE-KEY-DONT-SHARE";
 
-const RPC_API_KEY = "YOUR-API-KEY-FROM-YOUR-RPC-PROVIDER";
+const RPC_API_KEY = "YOUR-RPC-URL-FROM-YOUR-RPC-PROVIDER";
 
 /**
  * @type import('hardhat/config').HardhatUserConfig


### PR DESCRIPTION
<!-- Change RPC providers to POKT (Grove, Nodies and/or both)-->

## Changed

- [x] updated apps/academy/src/pages/tracks/nft-solidity/2.mdx as tastefully as possible - there is no explicit reference to alternative providers, but there **is** still a reference to Ankr in the `hardhat.config` file.
- [x] apps/academy/src/pages/tracks/nft-solidity/3.mdx - there is no mention of alternative RPC node providers

## Unable to change (see issue below)
- apps/academy/src/pages/tracks/nft-solidity/5.mdx imports `alchemyProvider` for `WAGMI`. Is it possible to change this?
I created this issue to address it: https://github.com/Developer-DAO/academy-turbo/issues/118

this is ready for review. Don't hold back on your suggestions to change the texts to something else, or change them back in some way. I'm just iterating on trying to get a good balance that isn't shilling too much. I appreciate your insights and wisdom 😁 
