### PR TITLE
author bio style tweaks

### DIFF
--- a/apps/academy/src/components/AboutCourse.tsx
+++ b/apps/academy/src/components/AboutCourse.tsx
@@ -6,7 +6,7 @@ interface AboutCourseProps {
 export default function AboutCourse({ lessonDescription, tags }: AboutCourseProps) {
   return (
     <article className="w-full px-7 pt-14 lg:w-full lg:p-0">
-      <h2 className="text-2xl font-bold lg:text-3xl">About this Track</h2>
+      <h2 className="text-2xl font-bold lg:text-3xl">About This Track</h2>
       <div className="mt-4 flex flex-col gap-2 lg:flex-row">
         {tags.map((tag, idx) => (
           <div

--- a/apps/academy/src/components/AboutCourse.tsx
+++ b/apps/academy/src/components/AboutCourse.tsx
@@ -6,7 +6,7 @@ interface AboutCourseProps {
 export default function AboutCourse({ lessonDescription, tags }: AboutCourseProps) {
   return (
     <article className="w-full px-7 pt-14 lg:w-full lg:p-0">
-      <h2 className="text-2xl font-bold lg:text-3xl">About This Course</h2>
+      <h2 className="text-2xl font-bold lg:text-3xl">About this Track</h2>
       <div className="mt-4 flex flex-col gap-2 lg:flex-row">
         {tags.map((tag, idx) => (
           <div

--- a/apps/academy/src/components/CreatedBy.tsx
+++ b/apps/academy/src/components/CreatedBy.tsx
@@ -8,6 +8,20 @@ interface CreatedByProps {
 }
 
 export default function CreatedBy({ author, authorTwitter }: CreatedByProps) {
+  // mvp: if multiple authors, split by comma and map to multiple links
+  const handles = authorTwitter.split(", ");
+  const twitterLinks = handles.map((handle, idx) => (
+    <a
+      key={idx}
+      className="pr-2 underline"
+      href={`https://x.com/${handle}`}
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      @{handle}
+    </a>
+  ));
+
   return (
     <section className="grid place-items-start pt-6 text-sm lg:mx-16 lg:text-xl">
       <div className="flex w-full">
@@ -19,14 +33,7 @@ export default function CreatedBy({ author, authorTwitter }: CreatedByProps) {
         <div className="ml-6 flex flex-col items-center lg:flex-row lg:items-start lg:gap-4">
           <article className="font-light">
             <p className="font-bold">{author}</p>
-            <a
-              className="underline"
-              href={`https://x.com/${authorTwitter}`}
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              @{authorTwitter}
-            </a>
+            {twitterLinks}
           </article>
         </div>
       </div>

--- a/apps/academy/src/components/CreatedBy.tsx
+++ b/apps/academy/src/components/CreatedBy.tsx
@@ -7,12 +7,7 @@ interface CreatedByProps {
   createdDate: string;
 }
 
-export default function CreatedBy({
-  author,
-  authorPosition,
-  authorTwitter,
-  createdDate,
-}: CreatedByProps) {
+export default function CreatedBy({ author, authorTwitter }: CreatedByProps) {
   return (
     <section className="grid place-items-start pt-6 text-sm lg:mx-16 lg:text-xl">
       <div className="flex w-full">
@@ -23,11 +18,15 @@ export default function CreatedBy({
         </Avatar>
         <div className="ml-6 flex flex-col items-center lg:flex-row lg:items-start lg:gap-4">
           <article className="font-light">
-            <p>
-              {author} @ {authorPosition}
-            </p>
-            <p>{createdDate}</p>
-            <p>Twitter {authorTwitter}</p>
+            <p className="font-bold">{author}</p>
+            <a
+              className="underline"
+              href={`https://x.com/${authorTwitter}`}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              @{authorTwitter}
+            </a>
           </article>
         </div>
       </div>

--- a/apps/academy/src/components/TrackAuthor.tsx
+++ b/apps/academy/src/components/TrackAuthor.tsx
@@ -11,6 +11,20 @@ export default function TrackAuthor({
   authorDescription,
   authorTwitter,
 }: TrackAuthorProps) {
+  // mvp: if multiple authors, split by comma and map to multiple links
+  const handles = authorTwitter.split(", ");
+  const twitterLinks = handles.map((handle, idx) => (
+    <a
+      key={idx}
+      className="pr-2 underline"
+      href={`https://x.com/${handle}`}
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      @{handle}
+    </a>
+  ));
+
   return (
     <div className="w-full px-7 pt-14 lg:w-full lg:p-0">
       <section className="grid place-items-start pt-3 text-sm lg:pt-6 lg:text-xl">
@@ -23,14 +37,7 @@ export default function TrackAuthor({
           <article className="mb-4 mt-2 gap-2 font-light lg:mt-7">
             <p className="font-bold">{author}</p>
             <p>{authorDescription}</p>
-            <a
-              className="underline"
-              href={`https://x.com/${authorTwitter}`}
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              @{authorTwitter}
-            </a>
+            {twitterLinks}
           </article>
         </div>
       </section>

--- a/apps/academy/src/components/TrackAuthor.tsx
+++ b/apps/academy/src/components/TrackAuthor.tsx
@@ -12,36 +12,28 @@ export default function TrackAuthor({
   authorTwitter,
 }: TrackAuthorProps) {
   return (
-    <section className="mx-6 grid place-items-start pt-3 text-sm lg:mx-16 lg:pt-6 lg:text-xl">
-      <p className="pl-2 text-left">Created by:</p>
-      <div className="flex flex-col items-center lg:flex-row lg:items-start lg:gap-4">
-        <Avatar className="h-10 w-10 lg:mt-7 lg:h-16 lg:w-16">
-          <AvatarImage src="/azuki.png" />
-          <AvatarFallback>Avatar</AvatarFallback>
-        </Avatar>
-        <article className="mb-4 mt-2 gap-2 font-light lg:mt-7">
-          <p>{author}</p>
-          <p>{authorDescription}</p>
-          <p>Twitter {authorTwitter}</p>
-        </article>
-      </div>
-      {/* <div className="mt-4">
-        <div className="mr-2 inline-flex h-8 w-14 items-center justify-center gap-2 rounded-3xl border border-neutral-600 border-opacity-30 bg-yellow-400 bg-opacity-40 p-2 backdrop-blur-md">
-          <div className="font-['Clash Display'] text-center text-sm font-semibold text-white">
-            Web3
-          </div>
+    <div className="w-full px-7 pt-14 lg:w-full lg:p-0">
+      <section className="grid place-items-start pt-3 text-sm lg:pt-6 lg:text-xl">
+        <p className="text-left">Created by:</p>
+        <div className="flex flex-col items-center lg:flex-row lg:items-start lg:gap-4">
+          <Avatar className="h-10 w-10 lg:mt-7 lg:h-16 lg:w-16">
+            <AvatarImage src="/azuki.png" />
+            <AvatarFallback>Avatar</AvatarFallback>
+          </Avatar>
+          <article className="mb-4 mt-2 gap-2 font-light lg:mt-7">
+            <p className="font-bold">{author}</p>
+            <p>{authorDescription}</p>
+            <a
+              className="underline"
+              href={`https://x.com/${authorTwitter}`}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              @{authorTwitter}
+            </a>
+          </article>
         </div>
-        <div className="mr-2 inline-flex h-8 w-14 items-center justify-center gap-2 rounded-3xl border border-neutral-600 border-opacity-30 bg-red-600 bg-opacity-30 p-2 backdrop-blur-md">
-          <div className="font-['Clash Display'] text-center text-sm font-semibold text-white">
-            Eth
-          </div>
-        </div>
-        <div className="inline-flex h-8 w-20 items-center justify-center gap-2 rounded-3xl border border-neutral-600 border-opacity-30 bg-cyan-400 bg-opacity-30 p-2 backdrop-blur-md">
-          <div className="font-['Clash Display'] text-center text-sm font-semibold text-white">
-            Beginner
-          </div>
-        </div>
-      </div> */}
-    </section>
+      </section>
+    </div>
   );
 }

--- a/apps/academy/src/components/TracksLayout.tsx
+++ b/apps/academy/src/components/TracksLayout.tsx
@@ -30,7 +30,7 @@ export default function TracksLayout({
         <div className="w-full">
           <AboutCourse lessonDescription={trackDescription} tags={tags} />
         </div>
-        <div className="text-left">
+        <div className="w-full">
           <TrackAuthor
             author={trackAuthor}
             authorDescription={trackAuthorDescription}

--- a/apps/academy/src/pages/tracks/erc-20-solidity/1.mdx
+++ b/apps/academy/src/pages/tracks/erc-20-solidity/1.mdx
@@ -13,9 +13,9 @@ import LessonInformationalModal from "../../../components/mdx/LessonInformationa
 
 <LessonLayout
    lessonTitle="Introduction to Smart Contract Development with Solidity" 
-   author="_7i7o, piablo"
+   author="7i7o, piablo"
    authorPosition="Developer_DAO"
-   authorTwitter="@7i7o.eth, @Skruffster"
+   authorTwitter="7i7o, Skruffster"
    createdDate="August 15, 2022"
 >
 

--- a/apps/academy/src/pages/tracks/erc-20-solidity/2.mdx
+++ b/apps/academy/src/pages/tracks/erc-20-solidity/2.mdx
@@ -15,9 +15,9 @@ import LessonQuestionsModal from "../../../components/mdx/LessonQuestionsModal";
 
 <LessonLayout
    lessonTitle="Your own ERC-20 Token: A Step-by-Step Guide using Foundry" 
-   author="_7i7o, piablo"
+   author="7i7o, piablo"
    authorPosition="Developer_DAO"
-   authorTwitter="@7i7o.eth, @Skruffster"
+   authorTwitter="7i7o, Skruffster"
    createdDate="October 15, 2023"
 >
 

--- a/apps/academy/src/pages/tracks/erc-20-solidity/index.tsx
+++ b/apps/academy/src/pages/tracks/erc-20-solidity/index.tsx
@@ -8,7 +8,7 @@ const Erc20SolidityTrackPage = () => {
   const lessonsArray = [
     {
       title: "Introduction to Smart Contract Development with Solidity",
-      author: "_7i7o, piablo", // ["_7i7o", "piablo"],
+      author: "7i7o, piablo", // ["_7i7o", "piablo"],
       imgPath: "/image16.png",
       description:
         "Beginner-friendly. Create your first Solidity smart contract and learn the fundamentals of blockchain development. Checkpoint quizzes included.",
@@ -17,7 +17,7 @@ const Erc20SolidityTrackPage = () => {
     },
     {
       title: "Your own ERC-20 Token: A Step-by-Step Guide using Foundry",
-      author: "_7i7o, piablo",
+      author: "7i7o, piablo",
       imgPath: "/image16.png",
       description:
         "Foundry demystified: ERC-20 token creation for beginners. Probing quizzes throughout. Grasp the fundamentals and empower yourself to build and customize.",
@@ -30,9 +30,9 @@ const Erc20SolidityTrackPage = () => {
       <TracksLayout
         trackTitle="Build a Fungible Token"
         trackDescription="Learn to create ERC-20 tokens using Foundry, progressing from the basics to advanced customisation. We will be exploring, testing, real-world applications, security practices, and the role of tokens in decentralised ecosystems. From DeFi to DAO's and everything in between, thanks to its simplicity, but versatility, the ERC-20 is going nowhere. Start with Solidity, or dive directly into token creation — empowering you to contribute to blockchain projects."
-        trackAuthor="_7i7o, piablo"
+        trackAuthor="7i7o, piablo"
         trackAuthorDescription="Authors are active Developer DAO members"
-        trackAuthorTwitter="@_7i7o.eth, @Skruffster"
+        trackAuthorTwitter="7i7o, Skruffster"
         tags={["Beginner", "Solidity", "ERC-20", "Foundry", "DeFi"]}
       >
         <div className="mt-14 flex flex-col gap-8 lg:grid lg:w-full lg:grid-cols-3 lg:gap-10">

--- a/apps/academy/src/pages/tracks/fundamentals/cli_lesson.mdx
+++ b/apps/academy/src/pages/tracks/fundamentals/cli_lesson.mdx
@@ -12,7 +12,7 @@ import LessonLayout from "../../../components/LessonLayout";
    lessonTitle="Command Line Interface (CLI) Basics: A Beginners Guide"
    author="piablo"
    authorPosition="D_D Academy & Mentorship"
-   authorTwitter="@Skruffster"
+   authorTwitter="Skruffster"
    createdDate="August 15, 2022"
 >
 

--- a/apps/academy/src/pages/tracks/fundamentals/code-editors.mdx
+++ b/apps/academy/src/pages/tracks/fundamentals/code-editors.mdx
@@ -12,7 +12,7 @@ import LessonLayout from "../../../components/LessonLayout";
    lessonTitle="Top IDEs for Efficient Coding" 
    author="john-mac.eth"
    authorPosition="GeorgeMac510"
-   authorTwitter="@GeorgeMac510"
+   authorTwitter="GeorgeMac510"
    createdDate="August 15, 2022"
 >
 

--- a/apps/academy/src/pages/tracks/fundamentals/connect-with-rpc.mdx
+++ b/apps/academy/src/pages/tracks/fundamentals/connect-with-rpc.mdx
@@ -11,7 +11,7 @@ import LessonLayout from "../../../components/LessonLayout";
    lessonTitle="Essential RPC Concepts for dApp Connectivity" 
    author="john-mac.eth"
    authorPosition="@GeorgeMac510"
-   authorTwitter="@GeorgeMac510"
+   authorTwitter="GeorgeMac510"
    createdDate="August 15, 2022"
 >
 

--- a/apps/academy/src/pages/tracks/fundamentals/decentralized-storage.mdx
+++ b/apps/academy/src/pages/tracks/fundamentals/decentralized-storage.mdx
@@ -11,7 +11,7 @@ import LessonLayout from "../../../components/LessonLayout";
    lessonTitle="Decentralized Storage" 
    author="john-mac.eth, pbillingsby"
    authorPosition="GeorgeMac510, @Arweave"
-   authorTwitter="@GeorgeMac510, @pbillingsby_"
+   authorTwitter="GeorgeMac510, pbillingsby_"
    createdDate="August 15, 2022"
 >
 ## How is data stored on the traditional internet?

--- a/apps/academy/src/pages/tracks/fundamentals/index.tsx
+++ b/apps/academy/src/pages/tracks/fundamentals/index.tsx
@@ -105,7 +105,7 @@ const FundamentalsTrackPage = () => {
         trackDescription="Access our Web3 Fundamentals offering, providing vital tools, infrastructure insights, and core concepts essential for developers. Cover CLI basics, NPM setup, wallet nuances, RPC connectivity, testnet significance, OpenZeppelin contracts, ERC token standards, decentralized storage protocols, preferred IDEs, and NFT hosting. Fundamental skills for practical project development."
         trackAuthor="elPiablo, georgemac510"
         trackAuthorDescription="The authors have a wealth of knowledge in the field of education and pedagogy"
-        trackAuthorTwitter="@GeorgeMac510, @Skruffster"
+        trackAuthorTwitter="GeorgeMac510, Skruffster"
         tags={["Entry", "Explorer", "Infra", "Blockchain", "Back-end", "Front-end", "Bash", "RPC"]}
       >
         <div className="mt-14 flex flex-col gap-8 lg:grid lg:w-full lg:grid-cols-3 lg:gap-10">

--- a/apps/academy/src/pages/tracks/fundamentals/install-npm.mdx
+++ b/apps/academy/src/pages/tracks/fundamentals/install-npm.mdx
@@ -11,7 +11,7 @@ import LessonLayout from "../../../components/LessonLayout";
    lessonTitle="Package Manager Basics: Installing NPM with NVM" 
    author="john-mac.eth"
    authorPosition="GeorgeMac510"
-   authorTwitter="@GeorgeMac510"
+   authorTwitter="GeorgeMac510"
    createdDate="August 15, 2022"
 >
 

--- a/apps/academy/src/pages/tracks/fundamentals/nft-hosting.mdx
+++ b/apps/academy/src/pages/tracks/fundamentals/nft-hosting.mdx
@@ -12,7 +12,7 @@ import LessonLayout from "../../../components/LessonLayout";
    lessonTitle="NFT Hosting on OpenSea and Rarible" 
    author="john-mac.eth"
    authorPosition="GeorgeMac510"
-   authorTwitter="@GeorgeMac510"
+   authorTwitter="GeorgeMac510"
    createdDate="August 15, 2022"
 >
 

--- a/apps/academy/src/pages/tracks/fundamentals/open_zeppelin.mdx
+++ b/apps/academy/src/pages/tracks/fundamentals/open_zeppelin.mdx
@@ -11,7 +11,7 @@ import LessonLayout from "../../../components/LessonLayout";
    lessonTitle="Basics of OpenZeppelin Smart Contracts" 
    author="piablo"
    authorPosition="D_D Academy & Mentorship"
-   authorTwitter="@Skruffster"
+   authorTwitter="Skruffster"
    createdDate="August 15, 2022"
 >
 

--- a/apps/academy/src/pages/tracks/fundamentals/testnets.mdx
+++ b/apps/academy/src/pages/tracks/fundamentals/testnets.mdx
@@ -9,9 +9,9 @@ import LessonLayout from "../../../components/LessonLayout";
 
 <LessonLayout
    lessonTitle="Testing… test, test, testnets. Why they matter in Web3" 
-   author="_7i7o, piablo"
+   author="7i7o, piablo"
    authorPosition="D_D Academy & Mentorship"
-   authorTwitter="@7i7o.eth, @Skruffster"
+   authorTwitter="7i7o, Skruffster"
    createdDate="August 15, 2022"
 >
 

--- a/apps/academy/src/pages/tracks/fundamentals/token-standards.mdx
+++ b/apps/academy/src/pages/tracks/fundamentals/token-standards.mdx
@@ -13,7 +13,7 @@ import LessonLayout from "../../../components/LessonLayout";
    lessonTitle="ERC-? Demystifying Token Standards in Web3" 
    author="piablo"
    authorPosition="D_D Academy & Mentorship"
-   authorTwitter="@Skruffster"
+   authorTwitter="Skruffster"
    createdDate="August 15, 2022"
 >
 

--- a/apps/academy/src/pages/tracks/fundamentals/wallets.mdx
+++ b/apps/academy/src/pages/tracks/fundamentals/wallets.mdx
@@ -12,7 +12,7 @@ import LessonLayout from "../../../components/LessonLayout";
    lessonTitle="Understanding Web3 Wallets"
    author="piablo"
    authorPosition="D_D Academy & Mentorship"
-   authorTwitter="@Skruffster"
+   authorTwitter="Skruffster"
    createdDate="August 15, 2022"
 >
 

--- a/apps/academy/src/pages/tracks/index.tsx
+++ b/apps/academy/src/pages/tracks/index.tsx
@@ -33,7 +33,7 @@ const TracksPage = () => {
     },
     {
       title: "Build a Fungible Token",
-      author: "_7i7o, piablo",
+      author: "7i7o, piablo",
       imgPath: "/image16.png",
       description:
         "Start with Solidity basics, or move straight on to creating an ERC-20 token using the Foundry development toolchain. Later, we'll explore more advanced concepts with real-world use cases, and best practices for creating and managing blockchain assets",

--- a/apps/academy/src/pages/tracks/intro-to-ethereum/1.mdx
+++ b/apps/academy/src/pages/tracks/intro-to-ethereum/1.mdx
@@ -14,7 +14,7 @@ import Question from "../../../components/mdx/Question";
    lessonTitle="A Developer's Guide to Ethereum, Pt. 1"
    author="wolovim"
    authorPosition="Ethereum Foundation"
-   authorTwitter="@wolovim.eth"
+   authorTwitter="wolovim"
    createdDate="August 15, 2023"
 >
 

--- a/apps/academy/src/pages/tracks/intro-to-ethereum/2.mdx
+++ b/apps/academy/src/pages/tracks/intro-to-ethereum/2.mdx
@@ -11,7 +11,7 @@ import QuizStatusChecker from "../../../components/mdx/QuizStatusChecker";
 <LessonLayout lessonTitle="A Developer's Guide to Ethereum, Pt. 2" 
   author="wolovim"
   authorPosition="Ethereum Foundation"
-  authorTwitter="@wolovim.eth"
+  authorTwitter="@wolovim"
   createdDate="August 15, 2023"  >
 
 Welcome back! In the first installment of this series we covered a lot of ground

--- a/apps/academy/src/pages/tracks/intro-to-ethereum/2.mdx
+++ b/apps/academy/src/pages/tracks/intro-to-ethereum/2.mdx
@@ -11,7 +11,7 @@ import QuizStatusChecker from "../../../components/mdx/QuizStatusChecker";
 <LessonLayout lessonTitle="A Developer's Guide to Ethereum, Pt. 2" 
   author="wolovim"
   authorPosition="Ethereum Foundation"
-  authorTwitter="@wolovim"
+  authorTwitter="wolovim"
   createdDate="August 15, 2023"  >
 
 Welcome back! In the first installment of this series we covered a lot of ground

--- a/apps/academy/src/pages/tracks/intro-to-ethereum/3.mdx
+++ b/apps/academy/src/pages/tracks/intro-to-ethereum/3.mdx
@@ -11,7 +11,7 @@ import QuizStatusChecker from "../../../components/mdx/QuizStatusChecker";
 <LessonLayout lessonTitle="A Developer's Guide to Ethereum, Pt. 3" 
   author="wolovim"
   authorPosition="Ethereum Foundation"
-  authorTwitter="@wolovim.eth"
+  authorTwitter="wolovim"
   createdDate="August 15, 2023" >
 
 Welcome to Part 3 in the saga! Part 1 covered blockchain fundamentals. Part 2 continued on to examine Ethereum accounts and how they enable participation in the network. Part 3 will build on those concepts with the introduction of smart contracts.

--- a/apps/academy/src/pages/tracks/intro-to-ethereum/index.tsx
+++ b/apps/academy/src/pages/tracks/intro-to-ethereum/index.tsx
@@ -40,8 +40,8 @@ const IntroToEthereumTrackPage = () => {
         trackTitle="A Developer's Guide to Ethereum"
         trackDescription="An accessible introduction to Ethereum via web3.py and Python. Grasp blockchain basics, Ethereum's decentralization, and smart contracts with practical insights. Code included for hands-on learning, but no programming expertise required."
         trackAuthor="wolovim"
-        trackAuthorDescription="wolovim is a Full Stack Python Developer at the Ethereum Foundation."
-        trackAuthorTwitter="@wolovim.eth"
+        trackAuthorDescription="Full-stack developer on the Ethereum Foundation's Python tooling team, helping to maintain web3.py, py-evm, and related open source libraries."
+        trackAuthorTwitter="wolovim"
         tags={["Entry", "Open Source", "Blockchain", "Ethereum", "Python", "Web3.py", "Node"]}
       >
         <div className="mt-14 flex flex-col gap-8 lg:grid lg:w-full lg:grid-cols-3 lg:gap-10">

--- a/apps/academy/src/pages/tracks/nft-solidity/1.mdx
+++ b/apps/academy/src/pages/tracks/nft-solidity/1.mdx
@@ -13,9 +13,9 @@ import LessonQuestionsModal from "../../../components/mdx/LessonQuestionsModal";
 
 <LessonLayout
    lessonTitle="Introduction to Smart Contract Development with Solidity" 
-   author="_7i7o, piablo"
+   author="7i7o, piablo"
    authorPosition="Developer_DAO"
-   authorTwitter="@7i7o.eth, @Skruffster"
+   authorTwitter="7i7o, Skruffster"
    createdDate="August 15, 2022"
 >
 

--- a/apps/academy/src/pages/tracks/nft-solidity/2.mdx
+++ b/apps/academy/src/pages/tracks/nft-solidity/2.mdx
@@ -19,9 +19,9 @@ import LessonInformationalModal from "../../../components/mdx/LessonInformationa
 
 <LessonLayout
    lessonTitle="Crafting a Basic NFT: A Step-by-Step ERC721 Tutorial for Beginners" 
-   author="_7i7o, piablo"
+   author="7i7o, piablo"
    authorPosition="Developer_DAO"
-   authorTwitter="@7i7o.eth, @Skruffster"
+   authorTwitter="7i7o, Skruffster"
    createdDate="August 15, 2022"
 >
 

--- a/apps/academy/src/pages/tracks/nft-solidity/3.mdx
+++ b/apps/academy/src/pages/tracks/nft-solidity/3.mdx
@@ -14,9 +14,9 @@ import Callout from "../../../components/mdx/Callout";
 
 <LessonLayout
    lessonTitle="Multi Tiered NFTs: A User-Friendly Guide to Building ERC721 Collections"
-   author="_7i7o, meowy, piablo"
+   author="7i7o, meowy, piablo"
    authorPosition="D_D Academy"
-   authorTwitter="@7i7o, @Skruffster"
+   authorTwitter="7i7o, Skruffster"
    createdDate="August 30, 2022"
 >
 ## About this lesson

--- a/apps/academy/src/pages/tracks/nft-solidity/4.mdx
+++ b/apps/academy/src/pages/tracks/nft-solidity/4.mdx
@@ -14,7 +14,7 @@ import QuizStatusChecker from "../../../components/mdx/QuizStatusChecker";
   lessonTitle="Smart Contracts: Automated Testing and Test-Driven Development (TDD)"
   author="brianfive, piablo"
   authorPosition="D_D Academy"
-  authorTwitter="@brianfive, @Skruffster"
+  authorTwitter="brianfive, Skruffster"
   createdDate="September 19, 2022"
 >
 

--- a/apps/academy/src/pages/tracks/nft-solidity/5.mdx
+++ b/apps/academy/src/pages/tracks/nft-solidity/5.mdx
@@ -19,7 +19,7 @@ import QuizStatusChecker from "../../../components/mdx/QuizStatusChecker";
   lessonTitle="Connect your Smart Contract to a Front End Application."
   author="ropats16"
   authorPosition="D_D Academy"
-  authorTwitter="@ropats16"
+  authorTwitter="ropats16"
   createdDate="September 22, 2022"
 >
 ## About this lesson

--- a/apps/academy/src/pages/tracks/nft-solidity/index.tsx
+++ b/apps/academy/src/pages/tracks/nft-solidity/index.tsx
@@ -8,7 +8,7 @@ const NftSolidityTrackPage = () => {
   const lessonsArray = [
     {
       title: "Introduction to Smart Contract Development with Solidity",
-      author: "_7i7o, piablo", // ["_7i7o", "piablo"],
+      author: "7i7o, piablo", // ["_7i7o", "piablo"],
       imgPath: "/image16.png",
       description:
         "Beginner-friendly. Create your first Solidity smart contract and learn the fundamentals of blockchain development. Checkpoint quizzes included.",
@@ -17,7 +17,7 @@ const NftSolidityTrackPage = () => {
     },
     {
       title: "Crafting a Basic NFT: A Step-by-Step ERC-721 Tutorial for Beginners",
-      author: "_7i7o, piablo", // ["_7i7o", "piablo"],
+      author: "7i7o, piablo", // ["_7i7o", "piablo"],
       imgPath: "/image16.png",
       description:
         "Use pro developer tools  and libraries to create and host your first ERC-721 NFT, for real world professional projects. Checkpoint quizzes included.",
@@ -26,7 +26,7 @@ const NftSolidityTrackPage = () => {
     },
     {
       title: "TierNFTs.",
-      author: "_7i7o, meowy, piablo", // ["_7i7o", "meowy", "piablo"],
+      author: "7i7o, meowy, piablo", // ["_7i7o", "meowy", "piablo"],
       imgPath: "/image16.png",
       description:
         "Create your first ERC-721 tiered NFT collection with an array of dev tools with probing quizzes along the way. Adapt your project for professional use cases.",
@@ -59,7 +59,7 @@ const NftSolidityTrackPage = () => {
         trackDescription="This ERC-721 NFT track will take you from complete beginner to building a series of meaningful, real-world, NFT projects. You'll enhance your skills along the way by using test-driven development to gain confidence that your smart contracts are safe to deploy to a live blockchain. And finally you'll be creating a tasteful front-end interface so your users can mint your ERC-721 tokens in their desired tier. All in all, a rewarding coding journey."
         trackAuthor="7i7o, piablo, georgemac510, brianfive, ropats16, meowy, mveve"
         trackAuthorDescription="Authors are active Developer DAO members"
-        trackAuthorTwitter="@_7i7o.eth"
+        trackAuthorTwitter="7i7o"
         tags={["Entry", "Remix", "Explorer", "Full Stack", "Solidity", "JavaScript"]}
       >
         <div className="mt-14 flex flex-col gap-8 lg:grid lg:w-full lg:grid-cols-3 lg:gap-10">


### PR DESCRIPTION
## Changes

- style tweaks for author bios on track page and lesson page, per figma
- dead simple approach for rendering multiple twitter handles
- fix broken handles

note: this is mvp-motivated. once the app natively supports multiple authors, this rendering logic can get tossed out.

### before examples:
<img width="1092" alt="Screenshot 2024-01-30 at 10 40 40 PM" src="https://github.com/Developer-DAO/academy-turbo/assets/3621728/4cdaea45-eec0-437b-b144-02646e0875eb">
<img width="759" alt="Screenshot 2024-01-30 at 10 41 31 PM" src="https://github.com/Developer-DAO/academy-turbo/assets/3621728/c9c4bc11-b6cc-4b5e-9e1b-ea1c9058d0a1">

### after examples:
<img width="1098" alt="Screenshot 2024-01-30 at 10 05 11 PM" src="https://github.com/Developer-DAO/academy-turbo/assets/3621728/29e75328-5f81-463a-9922-e4ffa786bc59">
<img width="287" alt="Screenshot 2024-01-30 at 10 05 37 PM" src="https://github.com/Developer-DAO/academy-turbo/assets/3621728/51f3c356-d381-48f8-9ec8-0c4a40448460">
<img width="1101" alt="Screenshot 2024-01-30 at 10 37 04 PM" src="https://github.com/Developer-DAO/academy-turbo/assets/3621728/4051e5e5-98ee-4215-8b4e-3e6b8f959707">
<img width="498" alt="Screenshot 2024-01-30 at 10 36 50 PM" src="https://github.com/Developer-DAO/academy-turbo/assets/3621728/48ad3a18-85dd-4e13-bb90-23c515d0751f">
