### PR TITLE
fix: lesson content container styling

### DIFF
--- a/apps/academy/src/components/CreatedBy.tsx
+++ b/apps/academy/src/components/CreatedBy.tsx
@@ -2,9 +2,7 @@ import { Avatar, AvatarFallback, AvatarImage } from "ui/components/ui/avatar";
 
 interface CreatedByProps {
   author: string;
-  authorPosition: string;
   authorTwitter: string;
-  createdDate: string;
 }
 
 export default function CreatedBy({ author, authorTwitter }: CreatedByProps) {
@@ -23,7 +21,7 @@ export default function CreatedBy({ author, authorTwitter }: CreatedByProps) {
   ));
 
   return (
-    <section className="grid place-items-start pt-6 text-sm lg:mx-16 lg:text-xl">
+    <section className="grid place-items-start pt-6 text-sm lg:text-xl">
       <div className="flex w-full">
         <p className="text-left">Created by:</p>
         <Avatar className="ml-6 h-16 w-16">
@@ -37,24 +35,6 @@ export default function CreatedBy({ author, authorTwitter }: CreatedByProps) {
           </article>
         </div>
       </div>
-
-      {/* <div className="mt-4">
-        <div className="mr-2 inline-flex h-8 w-14 items-center justify-center gap-2 rounded-3xl border border-neutral-600 border-opacity-30 bg-yellow-400 bg-opacity-40 p-2 backdrop-blur-md">
-          <div className="font-['Clash Display'] text-center text-sm font-semibold text-white">
-            Web3
-          </div>
-        </div>
-        <div className="mr-2 inline-flex h-8 w-14 items-center justify-center gap-2 rounded-3xl border border-neutral-600 border-opacity-30 bg-red-600 bg-opacity-30 p-2 backdrop-blur-md">
-          <div className="font-['Clash Display'] text-center text-sm font-semibold text-white">
-            Eth
-          </div>
-        </div>
-        <div className="inline-flex h-8 w-20 items-center justify-center gap-2 rounded-3xl border border-neutral-600 border-opacity-30 bg-cyan-400 bg-opacity-30 p-2 backdrop-blur-md">
-          <div className="font-['Clash Display'] text-center text-sm font-semibold text-white">
-            Beginner
-          </div>
-        </div>
-      </div> */}
     </section>
   );
 }

--- a/apps/academy/src/components/LessonLayout.tsx
+++ b/apps/academy/src/components/LessonLayout.tsx
@@ -14,30 +14,15 @@ export default function LessonLayout({
   children,
   lessonTitle,
   author,
-  authorPosition,
   authorTwitter,
-  createdDate,
 }: LessonLayoutProps) {
   return (
-    <main className="pt-32 text-white">
+    <main className="px-10 pt-36 text-white lg:mx-auto lg:max-w-screen-lg lg:pt-44">
       <section className="text-center">
-        <h1 className="font-future text-3xl lg:text-8xl">{lessonTitle}</h1>
-        <div className="ml-16 mt-7 h-px w-72 border border-white lg:w-[90%]"></div>
+        <h1 className="font-future text-3xl lg:text-7xl">{lessonTitle}</h1>
       </section>
-      <div className="mx-3 flex-col justify-start pt-4 lg:pt-24">
-        {/* <div className="">
-          <AboutCourse lessonDescription={lessonDescription} />
-        </div> */}
-        <div className="pl-6 text-left">
-          <CreatedBy
-            author={author}
-            authorPosition={authorPosition}
-            authorTwitter={authorTwitter}
-            createdDate={createdDate}
-          />
-        </div>
-      </div>
-      <div className="font-poppins px-10 pt-12 text-xl font-medium tracking-wider lg:px-36 lg:pt-16">
+      <CreatedBy author={author} authorTwitter={authorTwitter} />
+      <div className="font-poppins pt-4 text-xl font-medium tracking-wider lg:mx-auto lg:max-w-screen-lg">
         {children}
       </div>
     </main>


### PR DESCRIPTION
## Changes

- reduces lesson content width for better readability
- closes #82 
- not pixel perfect, but an mvp-motivated step in the right direction
- note: figma only includes the title underline for the Track page, not Lesson page, so i've removed it here

before:
<img width="1469" alt="Screenshot 2024-01-31 at 11 52 42 AM" src="https://github.com/Developer-DAO/academy-turbo/assets/3621728/b1882390-b951-46e0-a706-57db2535875e">
<img width="224" alt="Screenshot 2024-01-31 at 11 52 58 AM" src="https://github.com/Developer-DAO/academy-turbo/assets/3621728/ec81f216-0da7-41b7-b307-5af3c8e5dccb">


after:
<img width="1461" alt="Screenshot 2024-01-31 at 11 50 19 AM" src="https://github.com/Developer-DAO/academy-turbo/assets/3621728/afcbea15-32a3-48f5-bbe2-5f802c13ad90">
<img width="229" alt="Screenshot 2024-01-31 at 11 54 25 AM" src="https://github.com/Developer-DAO/academy-turbo/assets/3621728/d29ad403-7faa-4a93-a42b-fe1e5caa27bc">
