### PR TITLE
Fix: Steer users away from Next.js' newer App Router option until lesson supports that

### DIFF
--- a/apps/academy/src/pages/tracks/nft-solidity/5.mdx
+++ b/apps/academy/src/pages/tracks/nft-solidity/5.mdx
@@ -131,9 +131,9 @@ npx create-next-app frontend --use-npm
 ```
 
 For your next steps, choose 'No' to _TypeScript_, because we want to create a
-_JavaScript_ project, and also 'No' for _App Router_ option, since this lesson
-does not support that option in Next.js. Please choose the defaults for the
-other options:
+_JavaScript_ project, and also 'No' for _App Router_, since this lesson
+does not support that Next.js option yet, otherwise choose the default.
+Here are the options you should choose:
 
 ```bash
 Need to install the following packages:

--- a/apps/academy/src/pages/tracks/nft-solidity/5.mdx
+++ b/apps/academy/src/pages/tracks/nft-solidity/5.mdx
@@ -131,7 +131,9 @@ npx create-next-app frontend --use-npm
 ```
 
 For your next steps, choose 'No' to _TypeScript_, because we want to create a
-_JavaScript_ project, but choose 'Yes' to all the other options:
+_JavaScript_ project, and also 'No' for _App Router_ option, since this lesson
+does not support that option in Next.js. Please choose the defaults for the
+other options:
 
 ```bash
 Need to install the following packages:
@@ -141,7 +143,7 @@ Ok to proceed? (y) y
 ✔ Would you like to use ESLint? … Yes
 ✔ Would you like to use Tailwind CSS? … Yes
 ✔ Would you like to use `src/` directory? … Yes
-✔ Would you like to use App Router? (recommended) … Yes
+✔ Would you like to use App Router? (recommended) … No
 ✔ Would you like to customize the default import alias (@/*)? … Yes
 ✔ What import alias would you like configured? … @/*
 Creating a new Next.js app in ((path)):/developerdao/frontend.


### PR DESCRIPTION
The newer Next.js starter provides the option of creating an App Router version of the Next.js site.

This lesson hasn't been updated to use that yet.