### PR TITLE
fix: rollback index page style

### DIFF
--- a/apps/academy/src/pages/tracks/index.tsx
+++ b/apps/academy/src/pages/tracks/index.tsx
@@ -24,7 +24,7 @@ bg-[url('/bg_tracks.png')] bg-cover bg-no-repeat object-center pt-[300px]  lg:fi
         </div>
         <div />
       </div>
-      <div className="flex-0 flex lg:fixed lg:right-0 lg:top-20 lg:mx-24 lg:h-screen">
+      <div className="flex-0 flex lg:fixed lg:right-0 lg:top-20 lg:h-screen lg:w-1/2">
         <div className="relative flex max-h-screen w-full flex-1 flex-row space-y-10 overflow-y-scroll bg-black px-8 pb-14 lg:mb-40 lg:pb-28">
           <div className="flex w-full justify-center md:px-8 lg:mb-10 lg:pb-10">
             <div className="grid w-fit justify-center gap-5 sm:grid-cols-2 md:gap-x-10 md:gap-y-8 lg:grid-cols-1 lg:pb-8 xl:grid-cols-2">


### PR DESCRIPTION
## Changes

- rolled back a couple styles introduced in [this commit](https://github.com/Developer-DAO/academy-turbo/commit/ca7df128579741e742777e8c3faae32222aa3908#diff-4bcb721155a8beb422869f9945d1f2ccf579e777e3851038ce5b8c03e27796e1) that broke the track index page.
- closes #166 
- still to resolve: you can see a tag hanging off the end of one of the cards. one of us can fix that next.

before:
<img width="1482" alt="Screenshot 2024-02-12 at 3 50 08 PM" src="https://github.com/Developer-DAO/academy-turbo/assets/3621728/e8d12e09-548f-4c87-b858-7a64a019c8b0">


after:
<img width="1484" alt="Screenshot 2024-02-13 at 12 14 52 PM" src="https://github.com/Developer-DAO/academy-turbo/assets/3621728/2ae38cde-5742-49c0-a781-5f4be75c515c">

