### PR TITLE
Fix/lesson card size bugs

### DIFF
--- a/apps/academy/src/pages/tracks/erc-20-solidity/index.tsx
+++ b/apps/academy/src/pages/tracks/erc-20-solidity/index.tsx
@@ -29,7 +29,7 @@ const Erc20SolidityTrackPage = () => {
         trackAuthorTwitter="7i7o, Skruffster"
         tags={["Beginner", "Solidity", "ERC-20", "Foundry", "DeFi"]}
       >
-        <div className="mt-14 flex flex-col gap-8 lg:grid lg:w-full lg:grid-cols-4 lg:gap-10">
+        <div className="mt-14 flex flex-col gap-8 lg:grid lg:w-full lg:grid-cols-3 lg:gap-10">
           {allLessonsData !== undefined && allLessonsData.length > 0 ? (
             allLessonsData.map((lesson, idx) => {
               const tagsForThisLesson = lesson.tags.map((tag) => tag.tag.tagName);

--- a/apps/academy/src/pages/tracks/index.tsx
+++ b/apps/academy/src/pages/tracks/index.tsx
@@ -26,7 +26,7 @@ bg-[url('/bg_tracks.png')] bg-cover bg-no-repeat object-center pt-[300px]  lg:fi
       </div>
       <div className="flex-0 flex lg:fixed lg:right-0 lg:top-20 lg:h-screen lg:w-1/2">
         <div className="relative flex max-h-screen w-full flex-1 flex-row space-y-10 overflow-y-scroll bg-black px-8 pb-14 lg:mb-40 lg:pb-28">
-          <div className="flex w-full justify-center md:px-8 lg:mb-10 lg:pb-10">
+          <div className="flex w-full justify-center md:px-2 lg:mb-10 lg:pb-10">
             <div className="grid w-fit justify-center gap-5 sm:grid-cols-2 md:gap-x-10 md:gap-y-8 lg:grid-cols-1 lg:pb-8 xl:grid-cols-2">
               {allTracksData !== undefined && allTracksData.length > 0 ? (
                 allTracksData.map((track, idx) => (

--- a/apps/academy/src/pages/tracks/index.tsx
+++ b/apps/academy/src/pages/tracks/index.tsx
@@ -24,7 +24,7 @@ bg-[url('/bg_tracks.png')] bg-cover bg-no-repeat object-center pt-[300px]  lg:fi
         </div>
         <div />
       </div>
-      <div className="flex-0 flex lg:fixed lg:right-0 lg:top-20 lg:mx-24 lg:h-screen">
+      <div className="flex-0 flex lg:fixed lg:right-0 lg:top-20 lg:h-screen lg:w-1/2">
         <div className="relative flex max-h-screen w-full flex-1 flex-row space-y-10 overflow-y-scroll bg-black px-8 pb-14 lg:mb-40 lg:pb-28">
           <div className="flex w-full justify-center md:px-8 lg:mb-10 lg:pb-10">
             <div className="grid w-fit justify-center gap-5 sm:grid-cols-2 md:gap-x-10 md:gap-y-8 lg:grid-cols-1 lg:pb-8 xl:grid-cols-2">

--- a/apps/academy/src/pages/tracks/nft-solidity/index.tsx
+++ b/apps/academy/src/pages/tracks/nft-solidity/index.tsx
@@ -77,7 +77,7 @@ const NftSolidityTrackPage = () => {
         tags={["Entry", "Remix", "Explorer", "Full Stack", "Solidity", "JavaScript"]}
       >
         {!allLessonsDataIsLoading ? (
-          <div className="mt-14 flex flex-col gap-8 lg:grid lg:w-full lg:grid-cols-4 lg:gap-10">
+          <div className="mt-14 flex flex-col gap-8 lg:grid lg:w-full lg:grid-cols-3 lg:gap-10">
             {allLessonsData !== undefined && allLessonsData.length > 0
               ? allLessonsData.map((lesson, idx) => {
                   const tagsForThisLesson = lesson.tags.map((tag) => tag.tag.tagName);

--- a/packages/ui/src/components/Cards/TrackCard.tsx
+++ b/packages/ui/src/components/Cards/TrackCard.tsx
@@ -43,7 +43,7 @@ const TrackCard: FC<TrackCardProps> = ({ imgSrc, tags, title, description }) => 
         <CardTitle className="title">{title}</CardTitle>
         <CardDescription className="description">{description}</CardDescription>
       </CardHeader>
-      <Separator className="opacity-10" /> {/*# TODO: change opacity of the parent borRer*/}
+      <Separator className="opacity-10" />
     </Card>
   );
 };

--- a/packages/ui/src/components/Cards/TrackCard.tsx
+++ b/packages/ui/src/components/Cards/TrackCard.tsx
@@ -42,8 +42,8 @@ const TrackCard: FC<TrackCardProps> = ({ imgSrc, tags, title, description }) => 
       <CardHeader className="space-y-4 pb-10">
         <CardTitle className="title">{title}</CardTitle>
         <CardDescription className="description">{description}</CardDescription>
-        <Separator className="opacity-10" />
       </CardHeader>
+      <Separator className="opacity-10" /> {/*# TODO: change opacity of the parent borRer*/}
     </Card>
   );
 };

--- a/packages/ui/src/components/ui/separator.tsx
+++ b/packages/ui/src/components/ui/separator.tsx
@@ -18,7 +18,9 @@ const Separator = React.forwardRef<
     orientation={orientation}
     className={cn(
       "bg-border shrink-0",
-      orientation === "horizontal" ? "h-[1px] w-full" : "h-full w-[1px]",
+      orientation === "horizontal"
+        ? "absolute bottom-12 left-[3px] h-[1px] w-[98%]"
+        : "h-full w-[1px]",
       className,
     )}
     {...props}

--- a/packages/ui/src/styles.css
+++ b/packages/ui/src/styles.css
@@ -250,8 +250,9 @@
 }
 
 .track {
-  @apply gradient-blur h-[406px] max-w-[285px] rounded-[51px] border-none shadow-sm hover:bg-zinc-900;
+  @apply gradient-blur h-[446px] max-w-[285px] rounded-[51px] border-none shadow-sm hover:bg-zinc-900;
   @apply ring-[2px] ring-inset ring-[#E9E9E930] ring-offset-0;
+  overflow: hidden;
 }
 
 .track .gray-badge {


### PR DESCRIPTION
## Changes

- closes #167 
- re: lesson cards, reverts from 4 column view to 3 to quickly address the over-stuffed cards. can revisit 4 columns again post-mvp.
- absolutely positions the horizontal line within the cards

before:
A) 
<img width="1151" alt="Screenshot 2024-02-12 at 10 13 51 PM" src="https://github.com/Developer-DAO/academy-turbo/assets/3621728/40247f3d-6d8f-4e6b-a623-8cf8afdad81e">
B)
<img width="1484" alt="Screenshot 2024-02-13 at 12 14 52 PM" src="https://github.com/Developer-DAO/academy-turbo/assets/3621728/ccf6096d-cdba-48db-9912-bc8ffe1627e3">


after: 
A)
<img width="1466" alt="Screenshot 2024-02-13 at 1 37 04 PM" src="https://github.com/Developer-DAO/academy-turbo/assets/3621728/8b2547fe-987e-4af3-95e0-58e57f93ad13">
B)
<img width="1487" alt="Screenshot 2024-02-13 at 1 41 49 PM" src="https://github.com/Developer-DAO/academy-turbo/assets/3621728/6e0d1707-6fc7-48bc-b8da-fa107ff6cfee">
