### PR TITLE
fix: replace circular footer link

### DIFF
--- a/packages/ui/src/components/Footer/Footer.tsx
+++ b/packages/ui/src/components/Footer/Footer.tsx
@@ -18,7 +18,7 @@ interface FooterLinks {
 }
 
 const links: readonly FooterLinks[] = [
-  { name: "Academy", href: "https://academy.developerdao.com", tooltipText: "D_D Academy website" },
+  { name: "DAO", href: "https://developerdao.com", tooltipText: "Developer DAO website" },
   {
     name: "Feedback",
     href: "https://github.com/Developer-DAO/academy-turbo/issues/new/choose",


### PR DESCRIPTION
## Changes

- Academy's footer includes a link to... Academy, which seems redundant. As a suggestion, I've swapped it out for a link to the D_D website.